### PR TITLE
Potential fix for code scanning alert no. 5: Full server-side request forgery

### DIFF
--- a/autoparts.py
+++ b/autoparts.py
@@ -171,7 +171,13 @@ def ai_chat_openai(messages: List[Dict[str, str]], model: str, base_url: Optiona
 
 
 def ai_chat_ollama(messages: List[Dict[str, str]], model: str, base_url: Optional[str] = None) -> Optional[str]:
-    url = (base_url or "http://localhost:11434") + "/api/generate"
+    # Only allow requests to localhost Ollama instance for security
+    ALLOWED_OLLAMA_BASE_URLS = {"http://localhost:11434", "http://127.0.0.1:11434"}
+    ollama_url = base_url or "http://localhost:11434"
+    if ollama_url not in ALLOWED_OLLAMA_BASE_URLS:
+        # Reject or fallback -- here, fallback to default localhost
+        ollama_url = "http://localhost:11434"
+    url = ollama_url + "/api/generate"
     prompt = "\n\n".join([m.get("content", "") for m in messages])
     payload = {"model": model, "prompt": prompt, "stream": False}
     req = request.Request(url, method="POST")


### PR DESCRIPTION
Potential fix for [https://github.com/IRedScarface/Autoparts/security/code-scanning/5](https://github.com/IRedScarface/Autoparts/security/code-scanning/5)

To fix this full SSRF, **never use a user-provided `base_url` directly when making a network request**, unless it’s validated and restricted to known-safe endpoints. The safest mitigation is to maintain an allow-list of supported domains/URLs, and use the base URL only if it matches an allowed entry. If some flexibility is required (for internal or custom deployments), restrict to a well-defined allow-list by scheme, host, and maybe even port. At the very least, enforce that base URLs are exactly `"http://localhost:11434"`, or other known-safe values, and reject or ignore any others. If only the model is customizable (not the server), always use the default base URL.

- **Where to change:**  
  In `autoparts.py`, inside `ai_chat_ollama`, validate the `base_url` argument before composing the target URL. If not in the allowed list (for example, only `http://localhost:11434`), either reject the request (return `None` or raise an exception), or fallback to the default base URL.
- **What to add:**  
  Add a check in `ai_chat_ollama` before URL construction, allowing only approved base URLs (`http://localhost:11434` for now, or extend this with a list/set).
- **Extra notes:**  
  Needs import of `urllib.parse` (for robust URL parsing if needed).  
  If you want to support a configurable allow-list, define it within the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
