### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sys
 import tempfile
+import logging
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -776,7 +777,9 @@ async def plan_multi(
                 )
             results.append({"filename": f.filename, "plan": p, "ai_name": suggested})
         except SyntaxError as e:
-            results.append({"filename": f.filename, "error": f"SyntaxError: {e}"})
+            import logging
+            logging.exception(f"Syntax error encountered in file {f.filename} during /plan_multi request.")
+            results.append({"filename": f.filename, "error": "Invalid input: syntax error in provided code."})
     return JSONResponse({"files": results})
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/IRedScarface/Autoparts/security/code-scanning/2](https://github.com/IRedScarface/Autoparts/security/code-scanning/2)

The correct fix is to ensure that exception details (`e`) are not returned to users in the API response. Specifically, in the `plan_multi` endpoint, we should replace the specific error message with a generic, innocuous one ("Syntax error in provided code."). On the server side, we can log the full exception (including traceback if desired) using the built-in `logging` module—ensuring developers have access to error details for debugging. To do this, import `logging` at the top of the file (if not already available in the visible code), and insert a call to `logging.exception` in the exception handler. Only return the generic error message to the client.

**Relevant file/region/lines to change:**  
- In `plan_multi`, around lines 778-779 of `server.py`.
- Ensure `import logging` at the top (preferably with existing imports).
- Use `logging.exception()` to log the error, and return a fixed message for the user.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
