### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/server.py
+++ b/server.py
@@ -809,7 +809,8 @@ async def build(
         try:
             tree = ast.parse(src)
         except SyntaxError as e:
-            return JSONResponse({"error": f"SyntaxError: {e}"}, status_code=400)
+            logging.exception("Syntax error while parsing user input code")
+            return JSONResponse({"error": "Syntax error in your code. Please check your input."}, status_code=400)
 
         items, imports, main_block, mod_doc = extract_top_level_items(src, tree)
 


### PR DESCRIPTION
Potential fix for [https://github.com/IRedScarface/Autoparts/security/code-scanning/3](https://github.com/IRedScarface/Autoparts/security/code-scanning/3)

**General fix:**  
Replace the direct exposure of the caught `SyntaxError` (`e`) to the client with a generic user-friendly message. Log the detailed exception (with traceback) server-side for debugging. Avoid including the exception string, stack trace, or internals in responses visible to the user.

**Specific steps:**  
- Change line 812 so that instead of returning `{"error": f"SyntaxError: {e}"}` to the client, log the `SyntaxError` (including traceback) using the `logging` module.
- Return a generic error message to the client (e.g. `{"error": "Syntax error in your code. Please check your input."}`).
- Ensure `logging` is properly imported (already present as per line 11).
- Do **not** expose details such as exception messages or tracebacks to the user.

**Changes needed:**  
- Update the relevant code in the exception handler for the `SyntaxError` in the function starting near line 798.
- Ensure detailed error is logged (`logging.exception` or similar) and a generic message is returned via `JSONResponse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
