### PR TITLE
Support AI configuration via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment configuration for Autoparts
+
+# OpenAI settings
+OPENAI_API_KEY=sk-...
+
+# Default AI configuration for the autoparts CLI
+AI_PROVIDER=openai
+AI_MODEL=gpt-4o-mini
+AI_BASE_URL=https://api.openai.com/v1
+
+# Ollama defaults (used by server endpoints)
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=mistral

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 venv/
 .env
 .env.*
+!.env.example
 
 # Node / Vite
 ui/node_modules/

--- a/README.md
+++ b/README.md
@@ -49,12 +49,17 @@ pip install -r requirements.txt
 Create a `.env` file (you can copy from `.env.example`):
 ```
 # .env
-# If you want to use Ollama locally:
+# Default AI settings for the CLI
+AI_PROVIDER=openai  # or 'ollama'
+AI_MODEL=gpt-4o-mini
+AI_BASE_URL=https://api.openai.com/v1
+
+# OpenAI API key
+OPENAI_API_KEY=sk-...
+
+# Ollama defaults for server endpoints
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.1
-
-# If you want to use OpenAI:
-OPENAI_API_KEY=sk-...
 ```
 > Both Ollama and OpenAI are optional. If AI naming fails or is disabled, a local naming fallback is used.
 

--- a/autoparts.py
+++ b/autoparts.py
@@ -26,10 +26,13 @@ import os
 import re
 import sys
 import json
+from dotenv import load_dotenv
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Set, Tuple, Optional, Sequence
 from urllib import request, error
+
+load_dotenv()
 
 # ---------- Data types ----------
 
@@ -1150,12 +1153,21 @@ def main():
         "--ai-name", action="store_true", help="Suggest package name with AI"
     )
     ap.add_argument(
-        "--ai-provider", choices=["openai", "ollama"], default=None, help="AI provider"
+        "--ai-provider",
+        choices=["openai", "ollama"],
+        default=os.getenv("AI_PROVIDER"),
+        help="AI provider",
     )
     ap.add_argument(
-        "--ai-model", default=None, help="AI model (e.g., gpt-4o-mini / mistral)"
+        "--ai-model",
+        default=os.getenv("AI_MODEL"),
+        help="AI model (e.g., gpt-4o-mini / mistral)",
     )
-    ap.add_argument("--ai-base-url", default=None, help="AI API base URL (optional)")
+    ap.add_argument(
+        "--ai-base-url",
+        default=os.getenv("AI_BASE_URL"),
+        help="AI API base URL (optional)",
+    )
 
     args = ap.parse_args()
 

--- a/server.py
+++ b/server.py
@@ -12,6 +12,8 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+from dotenv import load_dotenv
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -32,6 +34,8 @@ from autoparts import (
     render_module,
     repack_components,
 )
+
+load_dotenv()
 
 APP_NAME = "autoparts API (Ollama, non-empty-safe)"
 DEFAULT_OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")


### PR DESCRIPTION
## Summary
- load `.env` at startup for the CLI and FastAPI server
- allow `AI_PROVIDER`, `AI_MODEL`, and `AI_BASE_URL` to set default AI options
- document environment variables and add `.env.example`

## Testing
- `python -m py_compile autoparts.py server.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae475a408328bef8a967258b5a8c